### PR TITLE
Configure static deployment for Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
 
+## Deploy on Render
+
+This repository is configured for static hosting on [Render](https://render.com/). The provided `render.yaml` will install dependencies, run `npm run build` to generate static output, and serve the contents of the `out` directory. See Render's [static site docs](https://render.com/docs/deploy-static-site) for more details.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  // Enable static HTML export for Render
+  output: 'export',
+  // Disable image optimization to allow static hosting
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: nikki-web-preview
+    env: static
+    buildCommand: npm install && npm run build
+    staticPublishPath: out


### PR DESCRIPTION
## Summary
- enable Next.js static export and unoptimized images for static hosting
- add Render blueprint configuring build and publish directory
- document Render deployment instructions in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c65bd008832c9c79f9884a3e9a9a